### PR TITLE
Update galaxyservers.yml

### DIFF
--- a/topics/admin/tutorials/ansible-galaxy/group_vars/galaxyservers.yml
+++ b/topics/admin/tutorials/ansible-galaxy/group_vars/galaxyservers.yml
@@ -1,6 +1,6 @@
 ---
 # Python 3 support
-pip_virtualenv_command: /usr/bin/python3 -m virtualenv # usegalaxy_eu.certbot, usegalaxy_eu.tiaas2, galaxyproject.galaxy
+pip_virtualenv_command: /usr/bin/python3 -m virtualenv --copies # usegalaxy_eu.certbot, usegalaxy_eu.tiaas2, galaxyproject.galaxy
 certbot_virtualenv_package_name: python3-virtualenv    # usegalaxy_eu.certbot
 pip_package: python3-pip                               # geerlingguy.pip
 


### PR DESCRIPTION
Version 23.01. Running pip_virtual_command without "--copies"  created an issue which was difficult to debug - jobs, both local and remote (cluster) would fail to start. They would only start if the galaxy framework is restarted (galaxyctl restart), would complete successfully but would throw an error `lib/galaxy/model/__init__.py: ModuleNotFoundError: No module named 'sqlalchemy'` Actually venv fails to install properly and the jobs from the cluster would ignore the venv's packages which do contain sqalchemy. Deleting the venv and restarting the ansible playbook with "--copies" switch solved the issue.